### PR TITLE
Remove map comprehensions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustcomp"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 authors = ["Hunter Davenport"]

--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 [![crates.io](https://img.shields.io/crates/v/rustcomp)](https://crates.io/crates/rustcomp)
 [![docs](https://docs.rs/rustcomp/badge.svg)](https://docs.rs/rustcomp)
 
-Adds vector, set, map, and iterator comprehensions to Rust via functional macros.
+Adds vector, set, map, and iterator comprehensions to Rust. This is achieved through a functional macro, `iter_comp!`, that expands to iterators. See the [documentation](https://docs.rs/rustcomp) for more information.


### PR DESCRIPTION
They are not necessary since `iter_comp!` can create a `HashMap` thanks to Rust's pattern matching,